### PR TITLE
Fix search page thumbnails by adding primary_image to /api/search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,8 @@ async function handleApiRequest(request: Request, env: Env, url: URL, path: stri
 			// Get Data
 			const query = `SELECT
 						id, name, province, municipality, latitude, longitude,
-						description, recognition_type, jurisdiction, recognition_date, architect
+						description, recognition_type, jurisdiction, recognition_date, architect,
+						(SELECT r2_url FROM images WHERE place_id = places.id ORDER BY display_order LIMIT 1) as primary_image
 					FROM places
 					${whereClause}
 					${orderBy} LIMIT ? OFFSET ?`;


### PR DESCRIPTION
The /api/search endpoint was missing the primary_image subquery that
/api/places already included. Search result cards were referencing
place.primary_image but the field was never returned, so all cards
fell through to the no-image placeholder. Added the same correlated
subquery to pull r2_url from the images table for each result.

https://claude.ai/code/session_01PYw5WyeMeZcq63sLKCuDEh