### PR TITLE
Add source attribution to expanded image overlay

### DIFF
--- a/website-src/src/pages/PlaceDetail.css
+++ b/website-src/src/pages/PlaceDetail.css
@@ -159,6 +159,13 @@
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
 }
 
+.overlay-source {
+  margin: 0.5rem 0 0;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.7);
+  text-align: center;
+}
+
 .overlay-controls {
   margin-top: 1rem;
   display: flex;

--- a/website-src/src/pages/PlaceDetail.jsx
+++ b/website-src/src/pages/PlaceDetail.jsx
@@ -216,6 +216,7 @@ function PlaceDetail({ language }) {
                 alt={expandedImage.alt || place.name}
                 className="expanded-image"
               />
+              <p className="overlay-source">{t.disclaimerSource}</p>
               <div className="overlay-controls">
                 <button className="overlay-btn" onClick={() => downloadImage(expandedImage)}>
                   {t.download}


### PR DESCRIPTION
Displays "Source: Canadian Register of Historic Places" (bilingual) beneath
each image when expanded in the lightbox, reusing the existing i18n strings.

https://claude.ai/code/session_01Cx2qwGE18V5s2XRv1xM9cc