### PR TITLE
Tighten API rate limits for non-commercial educational use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "historic-canada-api",
-	"version": "0.0.0",
+	"name": "historic-places-canada",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "historic-canada-api",
-			"version": "0.0.0",
+			"name": "historic-places-canada",
+			"version": "1.0.0",
 			"devDependencies": {
 				"@cloudflare/vitest-pool-workers": "^0.12.4",
 				"typescript": "^5.5.2",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,13 +3,13 @@
   "info": {
     "title": "Historic Places Canada API",
     "version": "1.0.0",
-    "description": "# Historic Places Canada Open Data API\n\nA free, open-access API providing comprehensive data about Canada's nationally recognized historic places. This API includes information about over 11,000 historic sites across Canada with geographic coordinates, images, descriptions, and metadata.\n\n## Features\n- **Bilingual Support**: All content available in English and French (use `lang` parameter)\n- **Rich Metadata**: Includes recognition dates, architectural styles, themes, and more\n- **Geographic Data**: Latitude/longitude coordinates for mapping\n- **Images**: High-quality historic photographs via R2 storage\n- **Full-Text Search**: Search across names, descriptions, architects, and more\n- **Advanced Filters**: Filter by province, type, theme, date range, and more\n\n## Rate Limiting\n- **Anonymous Users**: 100 requests per minute per IP address\n- Rate limit headers included in all responses:\n  - `X-RateLimit-Limit`: Maximum requests per window\n  - `X-RateLimit-Remaining`: Requests remaining in current window\n  - `X-RateLimit-Reset`: Unix timestamp when the limit resets\n- When limit exceeded, returns `429 Too Many Requests` with `Retry-After` header\n\n## Data Attribution\nData sourced from Parks Canada's Historic Places database. Please attribute:\n> \"Data from Historic Places Canada, Parks Canada\"\n\n## Support\nFor issues or questions, visit: https://github.com/Gorskiz/historic-places-canada-2\n",
+    "description": "# Historic Places Canada Open Data API\n\nA free, open-access API providing comprehensive data about Canada's nationally recognized historic places. This API includes information about over 11,000 historic sites across Canada with geographic coordinates, images, descriptions, and metadata.\n\n## Features\n- **Bilingual Support**: All content available in English and French (use `lang` parameter)\n- **Rich Metadata**: Includes recognition dates, architectural styles, themes, and more\n- **Geographic Data**: Latitude/longitude coordinates for mapping\n- **Images**: High-quality historic photographs via R2 storage\n- **Full-Text Search**: Search across names, descriptions, architects, and more\n- **Advanced Filters**: Filter by province, type, theme, date range, and more\n\n## Usage Policy\nThis data is licensed for **non-commercial, educational use only**. All uses must include attribution to the Canadian Register of Historic Places.\n\n## Rate Limiting\nStrict rate limits are enforced to protect copyrighted source data:\n- **General Endpoints** (stats, provinces, filters, individual places): 30 requests per minute per IP\n- **Data Endpoints** (search, place listings, map): 10 requests per minute per IP\n- Rate limit headers included in all responses:\n  - `X-RateLimit-Limit`: Maximum requests per window for the endpoint tier\n  - `X-RateLimit-Remaining`: Requests remaining in current window\n  - `X-RateLimit-Reset`: Unix timestamp when the limit resets\n- When limit exceeded, returns `429 Too Many Requests` with `Retry-After` header\n\n## Data Attribution\nData sourced from the Canadian Register of Historic Places (historicplaces.ca), Government of Canada. Please attribute:\n> \"Data sourced from the Canadian Register of Historic Places (historicplaces.ca), Government of Canada.\"\n\n## Support\nFor issues or questions, visit: https://github.com/Gorskiz/historic-places-canada-2\n",
     "contact": {
       "name": "API Support",
       "url": "https://historicplaces2.workers.dev"
     },
     "license": {
-      "name": "Open Data",
+      "name": "Non-Commercial, Educational Use Only",
       "url": "https://open.canada.ca/en/open-government-licence-canada"
     }
   },
@@ -102,8 +102,8 @@
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 1000,
-              "default": 100
+              "maximum": 50,
+              "default": 50
             }
           },
           {
@@ -409,7 +409,7 @@
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 1000,
+              "maximum": 50,
               "default": 50
             }
           },

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -15,17 +15,22 @@ info:
     - **Full-Text Search**: Search across names, descriptions, architects, and more
     - **Advanced Filters**: Filter by province, type, theme, date range, and more
 
+    ## Usage Policy
+    This data is licensed for **non-commercial, educational use only**. All uses must include attribution to the Canadian Register of Historic Places.
+
     ## Rate Limiting
-    - **Anonymous Users**: 100 requests per minute per IP address
+    Strict rate limits are enforced to protect copyrighted source data:
+    - **General Endpoints** (stats, provinces, filters, individual places): 30 requests per minute per IP
+    - **Data Endpoints** (search, place listings, map): 10 requests per minute per IP
     - Rate limit headers included in all responses:
-      - `X-RateLimit-Limit`: Maximum requests per window
+      - `X-RateLimit-Limit`: Maximum requests per window for the endpoint tier
       - `X-RateLimit-Remaining`: Requests remaining in current window
       - `X-RateLimit-Reset`: Unix timestamp when the limit resets
     - When limit exceeded, returns `429 Too Many Requests` with `Retry-After` header
 
     ## Data Attribution
-    Data sourced from Parks Canada's Historic Places database. Please attribute:
-    > "Data from Historic Places Canada, Parks Canada"
+    Data sourced from the Canadian Register of Historic Places (historicplaces.ca), Government of Canada. Please attribute:
+    > "Data sourced from the Canadian Register of Historic Places (historicplaces.ca), Government of Canada."
 
     ## Support
     For issues or questions, visit: https://github.com/Gorskiz/historic-places-canada-2
@@ -34,7 +39,7 @@ info:
     name: API Support
     url: https://historicplaces2.workers.dev
   license:
-    name: Open Data
+    name: Non-Commercial, Educational Use Only
     url: https://open.canada.ca/en/open-government-licence-canada
 
 servers:
@@ -124,8 +129,8 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 1000
-            default: 100
+            maximum: 50
+            default: 50
         - name: offset
           in: query
           description: Number of results to skip (for pagination)
@@ -377,7 +382,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 1000
+            maximum: 50
             default: 50
         - name: offset
           in: query

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -45,10 +45,17 @@ describe('Canadian Historic Places API', () => {
 		expect(response.headers.get('Content-Type')).toContain('text/html');
 	});
 
-	it('Rate limiter headers are present', async () => {
+	it('Rate limiter headers are present with global limit on non-data endpoint', async () => {
 		const request = new Request('http://example.com/api/provinces');
 		const response = await SELF.fetch(request);
-		expect(response.headers.has('X-RateLimit-Limit')).toBe(true);
-		expect(response.headers.has('X-RateLimit-Remaining')).toBe(true);
+		expect(response.headers.get('X-RateLimit-Limit')).toBe('30');
+		expect(response.headers.get('X-RateLimit-Remaining')).toBe('29');
+	});
+
+	it('Data endpoints report the tighter per-endpoint rate limit', async () => {
+		const request = new Request('http://example.com/api/search?q=test');
+		const response = await SELF.fetch(request);
+		expect(response.headers.get('X-RateLimit-Limit')).toBe('10');
+		expect(response.headers.get('X-RateLimit-Remaining')).toBe('9');
 	});
 });

--- a/website-src/src/pages/ApiDocs.jsx
+++ b/website-src/src/pages/ApiDocs.jsx
@@ -163,9 +163,10 @@ function ApiDocs({ language }) {
       quickStartTitle: 'Fetch 10 places from Ontario',
 
       rateLimit: 'Rate Limiting',
-      rateLimitText: 'To ensure fair usage and API stability, we implement rate limiting for all requests:',
+      rateLimitText: 'Because this data is licensed for non-commercial, educational use only, strict rate limits are in place to prevent bulk harvesting:',
       rateLimitPoints: [
-        'Anonymous users: 100 requests per minute per IP address',
+        'General endpoints (stats, provinces, filters, individual places): 30 requests per minute per IP',
+        'Data endpoints (search, place listings, map): 10 requests per minute per IP',
         'Rate limit headers included in all responses',
         'Requests exceeding the limit receive a 429 status code',
         'Retry-After header indicates when to retry'
@@ -258,9 +259,10 @@ function ApiDocs({ language }) {
       quickStartTitle: 'Récupérer 10 lieux de l\'Ontario',
 
       rateLimit: 'Limitation de Débit',
-      rateLimitText: 'Pour garantir une utilisation équitable et la stabilité de l\'API, nous mettons en œuvre une limitation de débit pour toutes les requêtes:',
+      rateLimitText: 'Ces données sont sous licence pour un usage non commercial et éducatif uniquement. Des limites strictes sont en vigueur pour empêcher le téléchargement massif:',
       rateLimitPoints: [
-        'Utilisateurs anonymes: 100 requêtes par minute par adresse IP',
+        'Points de terminaison généraux (statistiques, provinces, filtres, lieux individuels): 30 requêtes par minute par adresse IP',
+        'Points de terminaison de données (recherche, liste de lieux, carte): 10 requêtes par minute par adresse IP',
         'En-têtes de limitation inclus dans toutes les réponses',
         'Les requêtes dépassant la limite reçoivent un code d\'état 429',
         'L\'en-tête Retry-After indique quand réessayer'

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -47,7 +47,15 @@
 			"binding": "RATE_LIMITER",
 			"namespace_id": "1001",
 			"simple": {
-				"limit": 100,
+				"limit": 30,
+				"period": 60
+			}
+		},
+		{
+			"binding": "DATA_RATE_LIMITER",
+			"namespace_id": "1002",
+			"simple": {
+				"limit": 10,
 				"period": 60
 			}
 		}


### PR DESCRIPTION
Copyright on the source data restricts usage to non-commercial,
educational purposes only. Rate limits have been tightened and
tiered to discourage bulk scraping while keeping the site usable
for legitimate browsing:

- Global limit (all endpoints): 100 → 30 requests/min per IP
- Data endpoints (search, place listings, map): new 10 req/min
  tier enforced via a second Cloudflare Rate Limit binding
- Result caps: places/search limit param max 1000 → 50;
  map endpoint hard cap 100 000 → 500
- 429 responses now state the non-commercial/educational
  restriction explicitly
- All docs (ApiDocs EN+FR, OpenAPI JSON+YAML) updated with the
  new per-tier limits and usage-policy language
- License field in OpenAPI specs updated to
  "Non-Commercial, Educational Use Only"
- Added test asserting the tighter data-endpoint rate limit
  headers

https://claude.ai/code/session_01CHKcutrqdVAAWodDTV8RAH